### PR TITLE
Performance fix and few features

### DIFF
--- a/dagr/dagr.py
+++ b/dagr/dagr.py
@@ -186,6 +186,9 @@ class Dagr:
             if filesearch:
                 filelink = filesearch['src']
 
+        if current_page.find("span",{"itemprop": "title"}).text == "Literature":
+            raise DagrException("not an image")
+
         if not filelink:
             if mature_error:
                 if self.mature:

--- a/dagr/dagr.py
+++ b/dagr/dagr.py
@@ -14,7 +14,7 @@ import json
 import re
 import sys
 from getopt import gnu_getopt, GetoptError
-from os import getcwd, makedirs
+from os import getcwd, makedirs, utime
 from os.path import (
     abspath, basename, exists as path_exists,
     expanduser, join as path_join
@@ -26,6 +26,9 @@ from requests import (
     session as req_session
     )
 from mechanicalsoup import StatefulBrowser
+#Last Modified time imports
+from email.utils import parsedate
+from time import mktime
 
 # Python 2/3 compatibility stuff
 try:
@@ -142,6 +145,12 @@ class Dagr:
 
         if file_name is None:
             return get_resp.text
+
+        try: #Set file dates to last modified time. Fails on downloaded HTML pages
+            mod_time = mktime(parsedate(get_resp.headers.get("last-modified")))
+            utime(file_name, times=(mod_time, mod_time))
+        except:
+            pass
 
         return file_name
 

--- a/dagr/dagr.py
+++ b/dagr/dagr.py
@@ -187,7 +187,9 @@ class Dagr:
                 filelink = filesearch['src']
 
         if current_page.find("span",{"itemprop": "title"}).text == "Literature":
-            raise DagrException("not an image")
+            filelink = self.browser.get_url()
+            filename = basename(filelink+".html")
+            return (filename, filelink)
 
         if not filelink:
             if mature_error:


### PR DESCRIPTION
MechanicalSoup sends everything opened with it through html parser, resulting in significant CPU usage when opening images for download. follow_link also downloads the file, resulting in downloading same thing twice and discarding the first download. Commit ccb3a7d fixes that.

Commit 1d3fbd6 stops attempts on downloading items in the Literature category, preventing downloads of placeholders/deviantart logos, and prevents fringe cases like catching a unrelated download link from a journal in a "More From" section.

Commit 9853ccd saves those items as a html file. It's a bit of a hack because it does not modify links/content, meaning it will only display the page when opened from drive properly until DeviantArt changes the look of their site.

Commit c72d80a attempts to set modified time of downloaded file to header reported last modified time, in attempt to make it possible to sort the folder in matching order to the gallery.
Fails when last-modified header is not present, like on saving html pages from commit above.
